### PR TITLE
fix: marshal input as the last option for generic scalar

### DIFF
--- a/graphql/string.go
+++ b/graphql/string.go
@@ -64,6 +64,11 @@ func UnmarshalString(v any) (string, error) {
 	case nil:
 		return "", nil
 	default:
-		return "", fmt.Errorf("%T is not a string", v)
+		payload, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal value of type %T: %w", v, err)
+		}
+
+		return string(payload), nil
 	}
 }

--- a/graphql/string_test.go
+++ b/graphql/string_test.go
@@ -31,6 +31,8 @@ func TestString(t *testing.T) {
 		assert.Equal(t, "true", mustUnmarshalString(t, true))
 		assert.Equal(t, "false", mustUnmarshalString(t, false))
 		assert.Equal(t, "", mustUnmarshalString(t, nil))
+		assert.Equal(t, `{"hello":"world"}`, mustUnmarshalString(t, map[string]interface{}{"hello": "world"}))
+		assert.Equal(t, `{"hello":123}`, mustUnmarshalString(t, map[string]interface{}{"hello": 123}))
 	})
 }
 


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))

## Summary by Sourcery

Bug Fixes:
- Fix an issue where non-string scalar input values were not handled correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for unsupported types during data conversion, shifting from type-checking errors to JSON marshaling errors for clearer feedback.
- **Tests**
	- Added new test cases to verify the correct JSON string representation for various input types, ensuring robust functionality of the data conversion process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->